### PR TITLE
Emitowanie zdarzeń GA

### DIFF
--- a/prestashop/themes/yarntheme/modules/ps_imageslider/views/templates/hook/slider.tpl
+++ b/prestashop/themes/yarntheme/modules/ps_imageslider/views/templates/hook/slider.tpl
@@ -33,7 +33,15 @@
     <ul class="carousel-inner" role="listbox" aria-label="{l s='Carousel container' d='Shop.Theme.Global'}">
       {foreach from=$homeslider.slides item=slide name='homeslider'}
         <li class="carousel-item {if $smarty.foreach.homeslider.first}active{/if}" role="option" aria-hidden="{if $smarty.foreach.homeslider.first}false{else}true{/if}">
-          <a href="{$slide.url}">
+          <a href="{$slide.url}" onclick="banner_event()">
+            <script>
+              function banner_event() {
+                gtag('event', 'banner_click', {
+                    'url': '{$slide.url}'
+                    });
+              }
+            </script>
+
             <figure>
               <img src="{$slide.image_url}" alt="{$slide.legend|escape}" loading="lazy" width="1110" height="340">
               {if $slide.title || $slide.description}

--- a/prestashop/themes/yarntheme/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/prestashop/themes/yarntheme/templates/catalog/_partials/product-add-to-cart.tpl
@@ -55,6 +55,14 @@
           {include file='catalog/_partials/product-variants.tpl'}
         {/block}
         
+        <script>
+          function discounted_event(){
+            gtag('event', 'discounted_product_purchase', {
+              'url': '{$product.url}',
+              'product_name': '{$product.name}'
+            });
+          }
+        </script>
 
         <div class="add">
           <button
@@ -63,6 +71,9 @@
             type="submit"
             {if !$product.add_to_cart_url}
               disabled
+            {/if}
+            {if $product.has_discount}
+              onclick="discounted_event()"
             {/if}
           ><span class="cart-span">
             <i class="material-icons shopping-cart">&#xE547;</i>


### PR DESCRIPTION
Dodanie do szablonów fragmentów kodu odpowiedzialnych za emitowanie zdarzeń Google Analytics.

Wymaga instalacji modułu Google Analytics do Prestashop, aby mogło poprawnie działać.